### PR TITLE
Eta 0.8.6b2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ subprojects {
     // If we want to set this to true, we should find a way to cross build
     // against multiple intellij versions.
     updateSinceUntilBuild = false
-    plugins = ['gradle']
+    // 'properties' and 'Groovy' are needed due to the 'gradle' dependency
+    plugins = ['properties', 'Groovy', 'gradle']
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'eta-base'
 
 eta {
   version = '0.8.6b2'
-  etlasVersion = '1.3.0.0'
+  etlasVersion = '1.5.1.0'
   preInstallDependencies = true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'eta-base'
 
 eta {
-  version = '0.7.2b1'
+  version = '0.8.6b2'
   etlasVersion = '1.3.0.0'
   preInstallDependencies = true
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,9 @@
   <description>Eta language support for IntelliJ IDEA.</description>
 
   <depends>com.intellij.modules.lang</depends>
+  <!-- properties and groovy are needed due to the gradle dependency -->
+  <depends>com.intellij.properties</depends>
+  <depends>org.intellij.groovy</depends>
   <depends>org.jetbrains.plugins.gradle</depends>
 
   <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">


### PR DESCRIPTION
Upgrades Eta version to 0.8.6b2 to help with RTS exceptions in the lexer.

Also adds `properties` and `groovy` plugin dependencies to pass the test suite. Was getting the following errors -

`Problems found loading plugins:<p/>Plugin "Gradle" was not loaded: required plugin "org.intellij.groovy" not installed.<p/>Plugin "IntelliJ-Eta" was not loaded: required plugin "org.intellij.groovy" not installed.<p/><br><a href="disable">Disable not loaded plugins</a><p/><a href="edit">Open plugin manager</a>
`

`Problems found loading plugins:<p/>Plugin "Groovy" was not loaded: required plugin "com.intellij.properties" not installed.<p/>Plugin "Gradle" was not loaded: required plugin "com.intellij.properties" not installed.<p/>Plugin "IntelliJ-Eta" was not loaded: required plugin "com.intellij.properties" not installed.<p/><br><a href="disable">Disable not loaded plugins</a><p/><a href="edit">Open plugin manager</a>
`